### PR TITLE
ubi9/ubi-minimal rebase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9:9.0.0-1640 as build
+FROM registry.access.redhat.com/ubi9:9.0.0-1690 as build
 LABEL stage=builder
 
 RUN dnf install --nodocs -y nodejs nodejs-nodemon npm --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
@@ -21,7 +21,7 @@ RUN chown -R 1000:1000 .
 
 ## Release image
 #FROM registry.access.redhat.com/ubi9/nodejs-16-minimal:1-67
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.0.0-1644 
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.0.0-1687 
 
 USER 0
 #RUN microdnf update -y --nodocs --disableplugin=subscription-manager --setopt=install_weak_deps=0 && \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export DOCKER_HUB_ID ?= docker.io/walicki
 export HZN_ORG_ID ?= examples
 
 export SERVICE_NAME ?= service-node-red-hello-world
-export SERVICE_VERSION ?= 1.0.0
+export SERVICE_VERSION ?= 1.1.0
 export SERVICE_ORG_ID ?= $(HZN_ORG_ID)
 export PATTERN_NAME ?= policy-node-red-hello-world
 


### PR DESCRIPTION
Signed-off-by: John Walicki <johnwalicki@gmail.com>

This PR rebases on the latest ubi9 images that close several CVE vulnerabilities
```make
+FROM registry.access.redhat.com/ubi9:9.0.0-1690 as build
```
and
```make
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.0.0-1687 
```